### PR TITLE
fix(email-verify): add our own verification route

### DIFF
--- a/nhost/functions/_utils/graphql/users.ts
+++ b/nhost/functions/_utils/graphql/users.ts
@@ -56,3 +56,29 @@ export async function getUser(id: string): Promise<User | null> {
 
   return response.user;
 }
+
+const DELETE_USER_DATA = gql`
+  mutation DeleteUserData($id: uuid!) {
+    delete_team_subscriptions(where: { created_by: { _eq: $id } }) {
+      affected_rows
+    }
+    delete_user_subscriptions(where: { user_id: { _eq: $id } }) {
+      affected_rows
+    }
+    deleteUser(id: $id) {
+      id
+    }
+  }
+`;
+
+export async function deleteUser(id: string): Promise<boolean> {
+  const response = await GraphQLClient.request<{
+    delete_team_subscriptions: { affected_rows: number };
+    delete_user_subscriptions: { affected_rows: number };
+    deleteUser: { id: string };
+  }>(DELETE_USER_DATA, {
+    id,
+  });
+
+  return response.deleteUser.id === id;
+}

--- a/nhost/functions/_utils/stripe.ts
+++ b/nhost/functions/_utils/stripe.ts
@@ -47,6 +47,7 @@ export async function createStripeCustomer({ email, userId }: { email?: string; 
     email,
     metadata: {
       userId,
+      userEmail: email ?? '',
     },
   });
 

--- a/nhost/functions/events/user-signup.ts
+++ b/nhost/functions/events/user-signup.ts
@@ -1,13 +1,10 @@
 import { Request, Response } from 'express';
 
-import { getUser } from '../_utils/graphql/users';
-import { upsertSubscription } from '../_utils/graphql/subscriptions';
+import { getOrCreateCustomer } from '../_utils/graphql/subscriptions';
 
 export default async function userSignupHandler(req: Request, res: Response) {
   // Check header to make sure the request comes from Hasura
-  if (
-    req.headers['nhost-webhook-secret'] !== process.env.NHOST_WEBHOOK_SECRET
-  ) {
+  if (req.headers['nhost-webhook-secret'] !== process.env.NHOST_WEBHOOK_SECRET) {
     return res.status(400).send('Incorrect webhook secret');
   }
 
@@ -17,46 +14,10 @@ export default async function userSignupHandler(req: Request, res: Response) {
     return res.status(400).json({ error: 'no user found.' });
   }
 
-  const { email } = (await getUser(user.id)) ?? {};
-
-  if (!email) {
-    return res
-      .status(400)
-      .json({ error: `no email found for user ${user.id}` });
-  }
-
-  if (user.metadata?.student) {
-    try {
-      await upsertSubscription({ userId: user.id, planId: 'student' });
-
-      return res.status(200).json({
-        success: true,
-        message: `student subscription with email ${email} created.`,
-      });
-    } catch (error) {
-      console.log(error);
-      // @ts-ignore
-      return res.status(400).json({ error: error.toString() });
-    }
-  }
-
-  if (user.metadata?.openSource) {
-    try {
-      await upsertSubscription({ userId: user.id, planId: 'oss' });
-
-      return res.status(200).json({
-        success: true,
-        message: `oss subscription with email ${email} created.`,
-      });
-    } catch (error) {
-      console.log(error);
-      // @ts-ignore
-      return res.status(400).json({ error: error.toString() });
-    }
-  }
+  const stripeCustomerId = await getOrCreateCustomer(user.id);
 
   return res.status(200).json({
     success: true,
-    message: `user with email ${email} created.`,
+    message: `user with customer id ${stripeCustomerId} created.`,
   });
 }

--- a/nhost/functions/stripe/create-checkout.ts
+++ b/nhost/functions/stripe/create-checkout.ts
@@ -3,11 +3,7 @@ import stripe, { getLineItem } from '../_utils/stripe';
 import { authPost } from '../_utils/middleware';
 import { getOrCreateCustomer } from '../_utils/graphql/subscriptions';
 
-const createStripeCheckoutSession = async (
-  req: Request,
-  res: Response,
-  { userId }: { userId: string }
-) => {
+const createStripeCheckoutSession = async (req: Request, res: Response, { userId }: { userId: string }) => {
   const { plan, interval = 'month' } = req.body;
 
   if (!plan) {

--- a/nhost/functions/users/delete.ts
+++ b/nhost/functions/users/delete.ts
@@ -1,10 +1,27 @@
 import { Request, Response } from 'express';
 import { authPost } from '../_utils/middleware';
 import { deleteUser } from '../_utils/graphql/users';
+import stripe, { getStripeSubscription } from '../_utils/stripe';
+import { getSubscription } from '../_utils/graphql/subscriptions';
 
 async function deleteUserHandler(req: Request, res: Response, { userId }: { userId: string }) {
   if (!userId) {
     return res.status(405).send({ message: 'Bad request.' });
+  }
+
+  // cancel existing subscription
+  try {
+    const subscription = await getSubscription(userId);
+
+    if (subscription && subscription.stripe_customer_id) {
+      const stripeSubscription = await getStripeSubscription(subscription.stripe_customer_id);
+
+      if (stripeSubscription) {
+        await stripe.subscriptions.update(stripeSubscription.id, { cancel_at_period_end: true });
+      }
+    }
+  } catch (err) {
+    console.log(err);
   }
 
   const success = deleteUser(userId);

--- a/nhost/functions/users/delete.ts
+++ b/nhost/functions/users/delete.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from 'express';
+import { authPost } from '../_utils/middleware';
+import { deleteUser } from '../_utils/graphql/users';
+
+async function deleteUserHandler(req: Request, res: Response, { userId }: { userId: string }) {
+  if (!userId) {
+    return res.status(405).send({ message: 'Bad request.' });
+  }
+
+  const success = deleteUser(userId);
+
+  return res.status(200).send({ success });
+}
+
+export default authPost(deleteUserHandler);

--- a/nhost/nhost/emails/en/email-confirm-change/body.html
+++ b/nhost/nhost/emails/en/email-confirm-change/body.html
@@ -143,12 +143,7 @@
       bgcolor="#f6f6f6"
     >
       <tr>
-        <td
-          style="font-family: sans-serif; font-size: 14px; vertical-align: top"
-          valign="top"
-        >
-          &nbsp;
-        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">&nbsp;</td>
         <td
           class="container"
           style="
@@ -166,13 +161,7 @@
         >
           <div
             class="content"
-            style="
-              box-sizing: border-box;
-              display: block;
-              margin: 0 auto;
-              max-width: 580px;
-              padding: 10px;
-            "
+            style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px"
           >
             <!-- START CENTERED WHITE CONTAINER -->
             <table
@@ -206,23 +195,11 @@
                     border="0"
                     cellpadding="0"
                     cellspacing="0"
-                    style="
-                      border-collapse: separate;
-                      mso-table-lspace: 0pt;
-                      mso-table-rspace: 0pt;
-                      width: 100%;
-                    "
+                    style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%"
                     width="100%"
                   >
                     <tr>
-                      <td
-                        style="
-                          font-family: sans-serif;
-                          font-size: 14px;
-                          vertical-align: top;
-                        "
-                        valign="top"
-                      >
+                      <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">
                         <p
                           style="
                             font-family: sans-serif;
@@ -243,9 +220,8 @@
                             margin-bottom: 15px;
                           "
                         >
-                          you have requested to change your login email for
-                          React Flow Pro. Please use this link to confirm your
-                          new email:
+                          you have requested to change your login email for React Flow Pro. Please use this link to
+                          confirm your new email:
                         </p>
                         <table
                           role="presentation"
@@ -302,7 +278,7 @@
                                         bgcolor="#ff0072"
                                       >
                                         <a
-                                          href="${link}"
+                                          href="${clientUrl}/email-verification/verify?ticket=${ticket}&redirectTo=${redirectTo}&type=emailConfirmChange"
                                           target="_blank"
                                           style="
                                             border: solid 1px #ff0072;
@@ -341,26 +317,13 @@
             <!-- END CENTERED WHITE CONTAINER -->
 
             <!-- START FOOTER -->
-            <div
-              class="footer"
-              style="
-                clear: both;
-                margin-top: 10px;
-                text-align: center;
-                width: 100%;
-              "
-            >
+            <div class="footer" style="clear: both; margin-top: 10px; text-align: center; width: 100%">
               <table
                 role="presentation"
                 border="0"
                 cellpadding="0"
                 cellspacing="0"
-                style="
-                  border-collapse: separate;
-                  mso-table-lspace: 0pt;
-                  mso-table-rspace: 0pt;
-                  width: 100%;
-                "
+                style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%"
                 width="100%"
               >
                 <tr>
@@ -378,20 +341,10 @@
                     valign="top"
                     align="center"
                   >
-                    <span
-                      class="apple-link"
-                      style="
-                        color: #999999;
-                        font-size: 12px;
-                        text-align: center;
-                      "
+                    <span class="apple-link" style="color: #999999; font-size: 12px; text-align: center"
                       >React Flow Pro is developed by
                       <a
-                        style="
-                          text-decoration: underline !important;
-                          color: #999999;
-                          font-size: 12px;
-                        "
+                        style="text-decoration: underline !important; color: #999999; font-size: 12px"
                         href="https://webkid.io"
                         >webkid</a
                       ></span
@@ -401,12 +354,7 @@
                     <br />
                     <a
                       href="mailto:info@reactflow.dev"
-                      style="
-                        text-decoration: underline;
-                        color: #999999;
-                        font-size: 12px;
-                        text-align: center;
-                      "
+                      style="text-decoration: underline; color: #999999; font-size: 12px; text-align: center"
                       >info@reactflow.dev</a
                     >
                   </td>
@@ -416,12 +364,7 @@
             <!-- END FOOTER -->
           </div>
         </td>
-        <td
-          style="font-family: sans-serif; font-size: 14px; vertical-align: top"
-          valign="top"
-        >
-          &nbsp;
-        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">&nbsp;</td>
       </tr>
     </table>
   </body>

--- a/nhost/nhost/emails/en/email-verify/body.html
+++ b/nhost/nhost/emails/en/email-verify/body.html
@@ -143,12 +143,7 @@
       bgcolor="#f6f6f6"
     >
       <tr>
-        <td
-          style="font-family: sans-serif; font-size: 14px; vertical-align: top"
-          valign="top"
-        >
-          &nbsp;
-        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">&nbsp;</td>
         <td
           class="container"
           style="
@@ -166,13 +161,7 @@
         >
           <div
             class="content"
-            style="
-              box-sizing: border-box;
-              display: block;
-              margin: 0 auto;
-              max-width: 580px;
-              padding: 10px;
-            "
+            style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px"
           >
             <!-- START CENTERED WHITE CONTAINER -->
             <table
@@ -206,23 +195,11 @@
                     border="0"
                     cellpadding="0"
                     cellspacing="0"
-                    style="
-                      border-collapse: separate;
-                      mso-table-lspace: 0pt;
-                      mso-table-rspace: 0pt;
-                      width: 100%;
-                    "
+                    style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%"
                     width="100%"
                   >
                     <tr>
-                      <td
-                        style="
-                          font-family: sans-serif;
-                          font-size: 14px;
-                          vertical-align: top;
-                        "
-                        valign="top"
-                      >
+                      <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">
                         <p
                           style="
                             font-family: sans-serif;
@@ -243,8 +220,7 @@
                             margin-bottom: 15px;
                           "
                         >
-                          to activate your React Flow Pro account, please click
-                          the following link:
+                          to activate your React Flow Pro account, please click the following link:
                         </p>
                         <table
                           role="presentation"
@@ -301,7 +277,7 @@
                                         bgcolor="#ff0072"
                                       >
                                         <a
-                                          href="${link}"
+                                          href="${clientUrl}/email-verification/verify?ticket=${ticket}&redirectTo=${redirectTo}&type=emailVerify"
                                           target="_blank"
                                           style="
                                             border: solid 1px #ff0072;
@@ -339,13 +315,9 @@
                           "
                         >
                           By clicking the above link, you are accepting our
-                          <a href="https://pro.reactflow.dev/terms"
-                            >Terms of Service</a
-                          >
+                          <a href="https://pro.reactflow.dev/terms">Terms of Service</a>
                           and
-                          <a href="https://pro.reactflow.dev/privacy"
-                            >Privacy Policy</a
-                          >
+                          <a href="https://pro.reactflow.dev/privacy">Privacy Policy</a>
                           .
                         </p>
                         <p
@@ -370,26 +342,13 @@
             <!-- END CENTERED WHITE CONTAINER -->
 
             <!-- START FOOTER -->
-            <div
-              class="footer"
-              style="
-                clear: both;
-                margin-top: 10px;
-                text-align: center;
-                width: 100%;
-              "
-            >
+            <div class="footer" style="clear: both; margin-top: 10px; text-align: center; width: 100%">
               <table
                 role="presentation"
                 border="0"
                 cellpadding="0"
                 cellspacing="0"
-                style="
-                  border-collapse: separate;
-                  mso-table-lspace: 0pt;
-                  mso-table-rspace: 0pt;
-                  width: 100%;
-                "
+                style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%"
                 width="100%"
               >
                 <tr>
@@ -407,20 +366,10 @@
                     valign="top"
                     align="center"
                   >
-                    <span
-                      class="apple-link"
-                      style="
-                        color: #999999;
-                        font-size: 12px;
-                        text-align: center;
-                      "
+                    <span class="apple-link" style="color: #999999; font-size: 12px; text-align: center"
                       >React Flow Pro is developed by
                       <a
-                        style="
-                          text-decoration: underline !important;
-                          color: #999999;
-                          font-size: 12px;
-                        "
+                        style="text-decoration: underline !important; color: #999999; font-size: 12px"
                         href="https://webkid.io"
                         >webkid</a
                       ></span
@@ -430,12 +379,7 @@
                     <br />
                     <a
                       href="mailto:info@reactflow.dev"
-                      style="
-                        text-decoration: underline;
-                        color: #999999;
-                        font-size: 12px;
-                        text-align: center;
-                      "
+                      style="text-decoration: underline; color: #999999; font-size: 12px; text-align: center"
                       >info@reactflow.dev</a
                     >
                   </td>
@@ -445,12 +389,7 @@
             <!-- END FOOTER -->
           </div>
         </td>
-        <td
-          style="font-family: sans-serif; font-size: 14px; vertical-align: top"
-          valign="top"
-        >
-          &nbsp;
-        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">&nbsp;</td>
       </tr>
     </table>
   </body>

--- a/nhost/nhost/emails/en/password-reset/body.html
+++ b/nhost/nhost/emails/en/password-reset/body.html
@@ -143,12 +143,7 @@
       bgcolor="#f6f6f6"
     >
       <tr>
-        <td
-          style="font-family: sans-serif; font-size: 14px; vertical-align: top"
-          valign="top"
-        >
-          &nbsp;
-        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">&nbsp;</td>
         <td
           class="container"
           style="
@@ -166,13 +161,7 @@
         >
           <div
             class="content"
-            style="
-              box-sizing: border-box;
-              display: block;
-              margin: 0 auto;
-              max-width: 580px;
-              padding: 10px;
-            "
+            style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px"
           >
             <!-- START CENTERED WHITE CONTAINER -->
             <table
@@ -206,23 +195,11 @@
                     border="0"
                     cellpadding="0"
                     cellspacing="0"
-                    style="
-                      border-collapse: separate;
-                      mso-table-lspace: 0pt;
-                      mso-table-rspace: 0pt;
-                      width: 100%;
-                    "
+                    style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%"
                     width="100%"
                   >
                     <tr>
-                      <td
-                        style="
-                          font-family: sans-serif;
-                          font-size: 14px;
-                          vertical-align: top;
-                        "
-                        valign="top"
-                      >
+                      <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">
                         <p
                           style="
                             font-family: sans-serif;
@@ -243,8 +220,8 @@
                             margin-bottom: 15px;
                           "
                         >
-                          you have requested to change your login password for
-                          React Flow Pro. Please use this link to proceed:
+                          you have requested to change your login password for React Flow Pro. Please use this link to
+                          proceed:
                         </p>
                         <table
                           role="presentation"
@@ -301,7 +278,7 @@
                                         bgcolor="#ff0072"
                                       >
                                         <a
-                                          href="${link}"
+                                          href="${clientUrl}/email-verification/verify?ticket=${ticket}&redirectTo=${redirectTo}&type=passwordReset"
                                           target="_blank"
                                           style="
                                             border: solid 1px #ff0072;
@@ -340,26 +317,13 @@
             <!-- END CENTERED WHITE CONTAINER -->
 
             <!-- START FOOTER -->
-            <div
-              class="footer"
-              style="
-                clear: both;
-                margin-top: 10px;
-                text-align: center;
-                width: 100%;
-              "
-            >
+            <div class="footer" style="clear: both; margin-top: 10px; text-align: center; width: 100%">
               <table
                 role="presentation"
                 border="0"
                 cellpadding="0"
                 cellspacing="0"
-                style="
-                  border-collapse: separate;
-                  mso-table-lspace: 0pt;
-                  mso-table-rspace: 0pt;
-                  width: 100%;
-                "
+                style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%"
                 width="100%"
               >
                 <tr>
@@ -377,20 +341,10 @@
                     valign="top"
                     align="center"
                   >
-                    <span
-                      class="apple-link"
-                      style="
-                        color: #999999;
-                        font-size: 12px;
-                        text-align: center;
-                      "
+                    <span class="apple-link" style="color: #999999; font-size: 12px; text-align: center"
                       >React Flow Pro is developed by
                       <a
-                        style="
-                          text-decoration: underline !important;
-                          color: #999999;
-                          font-size: 12px;
-                        "
+                        style="text-decoration: underline !important; color: #999999; font-size: 12px"
                         href="https://webkid.io"
                         >webkid</a
                       ></span
@@ -400,12 +354,7 @@
                     <br />
                     <a
                       href="mailto:info@reactflow.dev"
-                      style="
-                        text-decoration: underline;
-                        color: #999999;
-                        font-size: 12px;
-                        text-align: center;
-                      "
+                      style="text-decoration: underline; color: #999999; font-size: 12px; text-align: center"
                       >info@reactflow.dev</a
                     >
                   </td>
@@ -415,12 +364,7 @@
             <!-- END FOOTER -->
           </div>
         </td>
-        <td
-          style="font-family: sans-serif; font-size: 14px; vertical-align: top"
-          valign="top"
-        >
-          &nbsp;
-        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">&nbsp;</td>
       </tr>
     </table>
   </body>

--- a/nhost/nhost/emails/en/signin-passwordless/body.html
+++ b/nhost/nhost/emails/en/signin-passwordless/body.html
@@ -143,12 +143,7 @@
       bgcolor="#f6f6f6"
     >
       <tr>
-        <td
-          style="font-family: sans-serif; font-size: 14px; vertical-align: top"
-          valign="top"
-        >
-          &nbsp;
-        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">&nbsp;</td>
         <td
           class="container"
           style="
@@ -166,13 +161,7 @@
         >
           <div
             class="content"
-            style="
-              box-sizing: border-box;
-              display: block;
-              margin: 0 auto;
-              max-width: 580px;
-              padding: 10px;
-            "
+            style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px"
           >
             <!-- START CENTERED WHITE CONTAINER -->
             <table
@@ -206,23 +195,11 @@
                     border="0"
                     cellpadding="0"
                     cellspacing="0"
-                    style="
-                      border-collapse: separate;
-                      mso-table-lspace: 0pt;
-                      mso-table-rspace: 0pt;
-                      width: 100%;
-                    "
+                    style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%"
                     width="100%"
                   >
                     <tr>
-                      <td
-                        style="
-                          font-family: sans-serif;
-                          font-size: 14px;
-                          vertical-align: top;
-                        "
-                        valign="top"
-                      >
+                      <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">
                         <p
                           style="
                             font-family: sans-serif;
@@ -243,8 +220,7 @@
                             margin-bottom: 15px;
                           "
                         >
-                          to sign-in to your React Flow Pro account, please
-                          click the following link:
+                          to sign-in to your React Flow Pro account, please click the following link:
                         </p>
                         <table
                           role="presentation"
@@ -301,7 +277,7 @@
                                         bgcolor="#ff0072"
                                       >
                                         <a
-                                          href="${link}"
+                                          href="${clientUrl}/email-verification/verify?ticket=${ticket}&redirectTo=${redirectTo}&type=signinPasswordless"
                                           target="_blank"
                                           style="
                                             border: solid 1px #ff0072;
@@ -339,13 +315,9 @@
                           "
                         >
                           By clicking the above link, you are accepting our
-                          <a href="https://pro.reactflow.dev/terms"
-                            >Terms of Service</a
-                          >
+                          <a href="https://pro.reactflow.dev/terms">Terms of Service</a>
                           and
-                          <a href="https://pro.reactflow.dev/privacy"
-                            >Privacy Policy</a
-                          >
+                          <a href="https://pro.reactflow.dev/privacy">Privacy Policy</a>
                           .
                         </p>
                         <p
@@ -370,26 +342,13 @@
             <!-- END CENTERED WHITE CONTAINER -->
 
             <!-- START FOOTER -->
-            <div
-              class="footer"
-              style="
-                clear: both;
-                margin-top: 10px;
-                text-align: center;
-                width: 100%;
-              "
-            >
+            <div class="footer" style="clear: both; margin-top: 10px; text-align: center; width: 100%">
               <table
                 role="presentation"
                 border="0"
                 cellpadding="0"
                 cellspacing="0"
-                style="
-                  border-collapse: separate;
-                  mso-table-lspace: 0pt;
-                  mso-table-rspace: 0pt;
-                  width: 100%;
-                "
+                style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%"
                 width="100%"
               >
                 <tr>
@@ -407,20 +366,10 @@
                     valign="top"
                     align="center"
                   >
-                    <span
-                      class="apple-link"
-                      style="
-                        color: #999999;
-                        font-size: 12px;
-                        text-align: center;
-                      "
+                    <span class="apple-link" style="color: #999999; font-size: 12px; text-align: center"
                       >React Flow Pro is developed by
                       <a
-                        style="
-                          text-decoration: underline !important;
-                          color: #999999;
-                          font-size: 12px;
-                        "
+                        style="text-decoration: underline !important; color: #999999; font-size: 12px"
                         href="https://webkid.io"
                         >webkid</a
                       ></span
@@ -430,12 +379,7 @@
                     <br />
                     <a
                       href="mailto:info@reactflow.dev"
-                      style="
-                        text-decoration: underline;
-                        color: #999999;
-                        font-size: 12px;
-                        text-align: center;
-                      "
+                      style="text-decoration: underline; color: #999999; font-size: 12px; text-align: center"
                       >info@reactflow.dev</a
                     >
                   </td>
@@ -445,12 +389,7 @@
             <!-- END FOOTER -->
           </div>
         </td>
-        <td
-          style="font-family: sans-serif; font-size: 14px; vertical-align: top"
-          valign="top"
-        >
-          &nbsp;
-        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top" valign="top">&nbsp;</td>
       </tr>
     </table>
   </body>

--- a/src/app/(auth)/email-verification/verify/page.tsx
+++ b/src/app/(auth)/email-verification/verify/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-// import { Link, Heading } from '@xyflow/xy-ui';
 import { redirect, useSearchParams } from 'next/navigation';
-// import { useEffect } from 'react';
 import { useNhostClient } from '@nhost/nextjs';
 
 export default function VerifyEmailPage() {
@@ -17,5 +15,5 @@ export default function VerifyEmailPage() {
     redirect(`${nhostClient.auth.url}/verify?ticket=${ticket}&type=${type}&redirectTo=${redirectTo}`);
   }
 
-  redirect('/');
+  redirect('/?error=invalid-ticket');
 }

--- a/src/app/(auth)/email-verification/verify/page.tsx
+++ b/src/app/(auth)/email-verification/verify/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+// import { Link, Heading } from '@xyflow/xy-ui';
+import { redirect, useSearchParams } from 'next/navigation';
+// import { useEffect } from 'react';
+import { useNhostClient } from '@nhost/nextjs';
+
+export default function VerifyEmailPage() {
+  const searchParams = useSearchParams();
+  const nhostClient = useNhostClient();
+
+  const ticket = searchParams.get('ticket');
+  const redirectTo = searchParams.get('redirectTo');
+  const type = searchParams.get('type');
+
+  if (ticket && redirectTo && type) {
+    redirect(`${nhostClient.auth.url}/verify?ticket=${ticket}&type=${type}&redirectTo=${redirectTo}`);
+  }
+
+  redirect('/');
+}

--- a/src/app/(dashboard)/account/_cards/change-email.tsx
+++ b/src/app/(dashboard)/account/_cards/change-email.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from 'react';
 import { useUserEmail, useChangeEmail } from '@nhost/nextjs';
-import { Card, CardHeader, CardTitle, CardFooter, Button, Input, InputLabel } from '@xyflow/xy-ui';
+import { Card, CardHeader, CardTitle, CardDescription, CardFooter, Button, Input, InputLabel } from '@xyflow/xy-ui';
 
 function ChangeEmailCard() {
   const email = useUserEmail();
-  const { changeEmail, isLoading } = useChangeEmail();
+  const { changeEmail, isLoading, needsEmailVerification, isError, error } = useChangeEmail();
   const [newEmail, setNewEmail] = useState<string>('');
 
   const handleSubmit = async (evt: React.SyntheticEvent) => {
@@ -18,6 +18,14 @@ function ChangeEmailCard() {
     <Card>
       <CardHeader>
         <CardTitle>Change Email</CardTitle>
+        {needsEmailVerification && (
+          <CardDescription>
+            Please confirm your new email by clicking the link we sent to <span className="font-bold">{newEmail}</span>.
+          </CardDescription>
+        )}
+        {isError && (
+          <CardDescription className="text-red-500">{error ? error.message : 'Something went wrong.'}</CardDescription>
+        )}
       </CardHeader>
       <CardFooter className="bg-muted space-x-10">
         <form onSubmit={handleSubmit} className="flex justify-between w-full">
@@ -32,9 +40,15 @@ function ChangeEmailCard() {
               required
               id="email"
               placeholder={email}
+              disabled={isLoading || needsEmailVerification}
             />
           </div>
-          <Button disabled={isLoading} className="shrink-0 ml-auto mt-auto" variant="react" type="submit">
+          <Button
+            disabled={isLoading || needsEmailVerification}
+            className="shrink-0 ml-auto mt-auto"
+            variant="react"
+            type="submit"
+          >
             Update Email
           </Button>
         </form>

--- a/src/app/(dashboard)/account/_cards/change-password.tsx
+++ b/src/app/(dashboard)/account/_cards/change-password.tsx
@@ -6,7 +6,7 @@ import { Card, CardHeader, CardDescription, CardTitle, CardFooter, Button, Input
 
 function ChangePasswordCard() {
   const [isLoading, setIsLoading] = useState(false);
-  const { changePassword, isSuccess } = useChangePassword();
+  const { changePassword, isSuccess, isError, error } = useChangePassword();
   const [newPassword, setNewPassword] = useState<string>('');
 
   const handleSubmit = async (evt: React.SyntheticEvent) => {
@@ -20,10 +20,13 @@ function ChangePasswordCard() {
     <Card>
       <CardHeader>
         <CardTitle>Change Password</CardTitle>
-        {isSuccess && <CardDescription className="text-green-500">Your password has been updated.</CardDescription>}
+        {isSuccess && <CardDescription className="text-green-600">Your password has been updated.</CardDescription>}
+        {isError && (
+          <CardDescription className="text-red-500">{error ? error.message : 'Something went wrong.'}</CardDescription>
+        )}
       </CardHeader>
-      <CardFooter className="bg-muted space-x-10">
-        <form onSubmit={handleSubmit} className="flex justify-between w-full">
+      <CardFooter className="bg-muted">
+        <form onSubmit={handleSubmit} className="flex space-x-2 justify-between w-full">
           <div className="flex-1">
             <InputLabel htmlFor="password">New Password</InputLabel>
             <Input

--- a/src/app/(dashboard)/account/_cards/delete-account.tsx
+++ b/src/app/(dashboard)/account/_cards/delete-account.tsx
@@ -1,17 +1,99 @@
-import { Card, CardHeader, CardTitle, CardDescription, CardFooter, Button } from '@xyflow/xy-ui';
+'use client';
+
+import { useState } from 'react';
+import { useSignOut, useUserEmail } from '@nhost/nextjs';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardFooter,
+  Button,
+  Input,
+} from '@xyflow/xy-ui';
+
+import useNhostFunction from '@/hooks/useNhostFunction';
 
 export default function DeleteAccountCard() {
+  const userEmail = useUserEmail();
+  const [confirmUserEmail, setConfirmUserEmail] = useState('');
+  const [isDeleteLoading, setIsDeleteLoading] = useState(false);
+  const nhostFunction = useNhostFunction();
+  const { signOut } = useSignOut();
+
+  const isDeleteConfirmed = userEmail === confirmUserEmail;
+
+  const deleteAccount = async () => {
+    if (isDeleteConfirmed) {
+      setIsDeleteLoading(true);
+
+      const { success } = await nhostFunction('/users/delete', {});
+
+      if (success) {
+        await signOut();
+      }
+
+      setIsDeleteLoading(false);
+    }
+  };
+
   return (
-    <Card className="border-red-500">
-      <CardHeader>
-        <CardTitle>Delete Account</CardTitle>
-        <CardDescription>
-          Use this button to delete your account and all your data. This action is irreversible.
-        </CardDescription>
-      </CardHeader>
-      <CardFooter>
-        <Button className="bg-red-500 hover:bg-red-400 -mt-4 mb-2">Delete Account</Button>
-      </CardFooter>
-    </Card>
+    <AlertDialog>
+      <Card className="border-red-500">
+        <CardHeader>
+          <CardTitle>Delete Account</CardTitle>
+
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+              <AlertDialogDescription className="flex flex-col gap-y-3">
+                <div>
+                  By clicking the button below, you will delete your React Flow Pro account. This action is
+                  irreversible. Please confirm that you want to:
+                </div>
+                <ul className="list-disc font-bold">
+                  <li>Delete your React Flow Pro account and all the data associated with it</li>
+                  <li>Cancel your subscription and lose access for the remaining time</li>
+                  <li>Remove access to the pro features for invited team members</li>
+                </ul>
+                <div>If you want to proceed, please enter your email in the form below:</div>
+                <Input
+                  onChange={(evt) => setConfirmUserEmail(evt.target.value)}
+                  value={confirmUserEmail}
+                  type="email"
+                  placeholder={`Type ${userEmail} to confirm...`}
+                  required
+                />
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction variant="react" disabled={!isDeleteConfirmed} onClick={() => deleteAccount()}>
+                {isDeleteLoading ? 'Please wait...' : 'Confirm Deletion'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+          <CardDescription>
+            Use this button to delete your account and all your data. This action is irreversible.
+          </CardDescription>
+        </CardHeader>
+        <CardFooter>
+          <AlertDialogTrigger>
+            <Button onClick={() => setConfirmUserEmail('')} className="bg-red-500 hover:bg-red-400 -mt-4 mb-2">
+              Delete Account
+            </Button>
+          </AlertDialogTrigger>
+        </CardFooter>
+      </Card>
+    </AlertDialog>
   );
 }

--- a/src/components/AuthForms/ResendVerificationLink.tsx
+++ b/src/components/AuthForms/ResendVerificationLink.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
-import { useSendVerificationEmail } from '@nhost/nextjs';
+import { useSignInEmailPasswordless } from '@nhost/nextjs';
 import { Button, Input, InputLabel } from '@xyflow/xy-ui';
 
 import { AuthErrorNotification, AuthNotification } from './AuthNotification';
@@ -10,17 +10,17 @@ import { AuthErrorNotification, AuthNotification } from './AuthNotification';
 function ResendVerificationLink() {
   const defaultEmail = useSearchParams()?.get('email');
   const [email, setEmail] = useState<string>(defaultEmail || '');
-  const { sendEmail, isLoading, isSent, isError, error } = useSendVerificationEmail();
+  const { signInEmailPasswordless, isSuccess, isLoading, isError, error } = useSignInEmailPasswordless();
 
   const handleSubmit = async (evt: React.SyntheticEvent) => {
     evt.preventDefault();
-    sendEmail(email);
+    signInEmailPasswordless(email);
   };
 
   return (
     <form onSubmit={handleSubmit}>
       {isError && <AuthErrorNotification error={error} />}
-      {isSent && (
+      {isSuccess && (
         <AuthNotification
           variant="success"
           title="We have sent you a link"


### PR DESCRIPTION
this PR adds a new route `/email-verification/verify` that is used in the email templates instead of redirecting to nhost directly. based on [this issue](https://github.com/nhost/nhost/issues/2314).

this should fix the signup for users who are using MS Outlook with certain security features.

closes #40 
closes #43 

other things addressed in this PR:

* implement the delete user button that deletes all user data and cancels the subscription
* create a new stripe customer on sign up (#38)
* output error and success messages in email and password change cards