### PR TITLE
💄 Make active editor file more prominent.

### DIFF
--- a/src/components/ProExampleViewer/tabs/editor.tsx
+++ b/src/components/ProExampleViewer/tabs/editor.tsx
@@ -20,11 +20,16 @@ const ignoreFiles = [
   '/tsconfig.node.json',
 ];
 
+const theme = {
+  ...aquaBlue,
+  colors: { ...aquaBlue.colors, accent: 'hsl(var(--primary))' },
+};
+
 function ProExampleCodeEditor({ files }: { files: SandpackFiles }) {
   const visibleFiles = files ? Object.keys(files).filter((file) => !ignoreFiles.includes(file)) : [];
 
   return (
-    <SandpackProvider options={{ visibleFiles, activeFile: 'src/App.tsx' }} files={files} theme={aquaBlue}>
+    <SandpackProvider options={{ visibleFiles, activeFile: 'src/App.tsx' }} files={files} theme={theme}>
       <SandpackLayout>
         <SandpackFileExplorer style={{ height: editorHeight }} autoHiddenFiles />
         <SandpackCodeEditor wrapContent style={{ height: editorHeight }} showLineNumbers showTabs={false} />


### PR DESCRIPTION
Uses how brand hot pink as the active file colour for the Sandpack editors. 

Before:

![Screenshot 2024-02-09 at 10 00 46](https://github.com/xyflow/pro-platform/assets/9001354/ff87a84c-6963-4861-b01a-cc66573fd001)

After:

![Screenshot 2024-02-09 at 10 00 29](https://github.com/xyflow/pro-platform/assets/9001354/cdab3c1e-9055-4e4d-844e-5849d9d3fc7a)

Closes #39.